### PR TITLE
refactor(pytest): Refactor PytestNeotestAdapter

### DIFF
--- a/neotest_python/__init__.py
+++ b/neotest_python/__init__.py
@@ -3,7 +3,7 @@ import json
 from enum import Enum
 from typing import List
 
-from neotest_python.base import NeotestResult
+from neotest_python.base import NeotestAdapter, NeotestResult
 
 
 class TestRunner(str, Enum):
@@ -11,7 +11,7 @@ class TestRunner(str, Enum):
     UNITTEST = "unittest"
 
 
-def get_adapter(runner: TestRunner):
+def get_adapter(runner: TestRunner) -> NeotestAdapter:
     if runner == TestRunner.PYTEST:
         from .pytest import PytestNeotestAdapter
 
@@ -43,6 +43,7 @@ parser.add_argument("args", nargs="*")
 def main(argv: List[str]):
     args = parser.parse_args(argv)
     adapter = get_adapter(TestRunner(args.runner))
+
     with open(args.stream_file, "w") as stream_file:
 
         def stream(pos_id: str, result: NeotestResult):
@@ -50,5 +51,6 @@ def main(argv: List[str]):
             stream_file.flush()
 
         results = adapter.run(args.args, stream)
+
     with open(args.results_file, "w") as results_file:
         json.dump(results, results_file)

--- a/neotest_python/base.py
+++ b/neotest_python/base.py
@@ -1,5 +1,6 @@
+import abc
 from enum import Enum
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional
 
 
 class NeotestResultStatus(str, Enum):
@@ -29,7 +30,8 @@ else:
     NeotestResult = Dict
 
 
-class NeotestAdapter:
+class NeotestAdapter(abc.ABC):
+
     def update_result(
         self, base: Optional[NeotestResult], update: NeotestResult
     ) -> NeotestResult:
@@ -40,3 +42,8 @@ class NeotestAdapter:
             "errors": (base.get("errors") or []) + (update.get("errors") or []) or None,
             "short": (base.get("short") or "") + (update.get("short") or ""),
         }
+
+    @abc.abstractmethod
+    def run(self, args: List[str], stream: Callable):
+        del args, stream
+        raise NotImplementedError


### PR DESCRIPTION
This commit does refactoring on NeotestResultCollector to make it a module-level class with a reference to NeotestAdapter.

Why? Having `NeotestResultCollector` (a pytest plugin) as an inner local class would make the code a bit difficult to read due to quite much indentation and lots of closures.

Context: I'm working on adding DAP (debugpy) integration, and I wrote this refactoring to make the implementation of DAP integration easier.