### PR TITLE
pytest: implement pytest_runtest_makereport to decouple exception handling from --tb argument value

### DIFF
--- a/neotest_python/pytest.py
+++ b/neotest_python/pytest.py
@@ -120,7 +120,8 @@ class NeotestResultCollector:
             else:
                 # TODO: Figure out how these are returned and how to represent
                 raise Exception(
-                    "Unhandled error type, please report to neotest-python repo"
+                    f"Unhandled error type ({type(exc_repr)}), please report to"
+                    " neotest-python repo"
                 )
         result: NeotestResult = self.adapter.update_result(
             self.results.get(pos_id),

--- a/neotest_python/pytest.py
+++ b/neotest_python/pytest.py
@@ -99,14 +99,14 @@ class NeotestResultCollector:
         short = self._get_short_output(self.pytest_config, report)
 
         if report.outcome == "failed":
-            from _pytest._code.code import ExceptionChainRepr
+            from _pytest._code.code import ExceptionRepr
 
             exc_repr = report.longrepr
             # Test fails due to condition outside of test e.g. xfail
             if isinstance(exc_repr, str):
                 errors.append({"message": exc_repr, "line": None})
             # Test failed internally
-            elif isinstance(exc_repr, ExceptionChainRepr):
+            elif isinstance(exc_repr, ExceptionRepr):
                 reprtraceback = exc_repr.reprtraceback
                 error_message = exc_repr.reprcrash.message  # type: ignore
                 error_line = None


### PR DESCRIPTION
And a minor improvement to error output.