### PR TITLE
feat(query): include test decorators in the test definition

### DIFF
--- a/lua/neotest-python/init.lua
+++ b/lua/neotest-python/init.lua
@@ -83,14 +83,31 @@ end
 ---@return Tree | nil
 function PythonNeotestAdapter.discover_positions(path)
   local query = [[
+    ;; Match undecorated functions
     ((function_definition
       name: (identifier) @test.name)
       (#match? @test.name "^test"))
       @test.definition
+    ;; Match decorated function, including decorators in definition
+    (decorated_definition
+      ((function_definition
+        name: (identifier) @test.name)
+        (#match? @test.name "^test")))
+        @test.definition
 
-    (class_definition
-     name: (identifier) @namespace.name)
-     @namespace.definition
+    ;; Match decorated classes, including decorators in definition
+    (decorated_definition
+      (class_definition
+       name: (identifier) @namespace.name))
+      @namespace.definition
+    ;; Match undecorated classes: namespaces nest so #not-has-parent is used
+    ;; to ensure each namespace is annotated only once
+    (
+     (class_definition
+      name: (identifier) @namespace.name)
+      @namespace.definition
+     (#not-has-parent? @namespace.definition decorated_definition)
+    )
   ]]
   local root = PythonNeotestAdapter.root(path)
   local python = get_python(root)


### PR DESCRIPTION
This means that `neotest.run.run` when the cursor is on a test's decorators will run the decorated test (instead of running the previous test in the file, the current behaviour).

Fixes: #31