### PR TITLE
Use pytest to populate parameterized test instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ require("neotest").setup({
         is_test_file = function(file_path)
           ...
         end,
-        
+        -- !!EXPERIMENTAL!! Enable shelling out to `pytest` to discover test
+        -- instances for files containing a parametrize mark (default: false)
+        pytest_discover_instances = true,
     })
   }
 })

--- a/lua/neotest-python/init.lua
+++ b/lua/neotest-python/init.lua
@@ -92,7 +92,6 @@ local function add_test_instances(root, positions, test_instances)
         if test_instances[comparable_id] == nil then
             goto continue
         end
-        local parent = value:parent()
         for _, test_instance in pairs(test_instances[comparable_id]) do
             local new_data = vim.tbl_extend("force", data, {
                 id = data.id .. test_instance,

--- a/lua/neotest-python/init.lua
+++ b/lua/neotest-python/init.lua
@@ -124,7 +124,7 @@ function PythonNeotestAdapter.discover_positions(path)
     require_namespaces = runner == "unittest",
   })
 
-  pytest.add_discovered_positions(root, positions)
+  pytest.add_discovered_positions(root, positions, path)
 
   return positions
 end

--- a/lua/neotest-python/init.lua
+++ b/lua/neotest-python/init.lua
@@ -87,17 +87,13 @@ local function add_test_instances(root, positions, test_instances)
         if data.type ~= "test" then
             goto continue
         end
-        logger.debug("N", data)
         local _, end_idx = string.find(data.id, root .. "/", 1, true)
         local comparable_id = string.sub(data.id, end_idx + 1)
         if test_instances[comparable_id] == nil then
             goto continue
         end
         local parent = value:parent()
-        logger.debug("P", parent)
         for _, test_instance in pairs(test_instances[comparable_id]) do
-            logger.debug("T", test_instance, data.id .. test_instance)
-
             local new_data = vim.tbl_extend("force", data, {
                 id = data.id .. test_instance,
                 name = data.name .. test_instance,
@@ -105,7 +101,6 @@ local function add_test_instances(root, positions, test_instances)
             })
 
             local new_pos = value:new(new_data, {}, value._key, {}, {})
-            logger.debug("NT", new_pos)
             value:add_child(new_data.id, new_pos)
         end
         ::continue::
@@ -143,7 +138,7 @@ function PythonNeotestAdapter.discover_positions(path)
   if runner == "pytest" and has_parametrize(path) then
     -- Launch an async job to collect test instances from pytest
     local cmd = table.concat(vim.tbl_flatten({ python, get_script(), "--pytest-collect" , path}), " ")
-    logger.debug(cmd)
+    logger.debug("Running test instance discovery:", cmd)
 
     _, pytest_job = pcall(async.fn.jobstart, cmd, {
       pty = true,
@@ -151,7 +146,6 @@ function PythonNeotestAdapter.discover_positions(path)
         for _, line in pairs(data) do
           local test_id, param_id = string.match(line, "(.+::.+)(%[.+%])\r?")
           if test_id and param_id then
-            logger.debug("MATCH", test_id, param_id, test_instances[test_id])
             if test_instances[test_id] == nil then
                 test_instances[test_id] = {param_id}
             else

--- a/lua/neotest-python/init.lua
+++ b/lua/neotest-python/init.lua
@@ -88,8 +88,13 @@ function PythonNeotestAdapter.discover_positions(path)
   local python = get_python(root)
   local runner = get_runner(python)
 
-  if runner == "pytest" and pytest_discover_instances and pytest.has_parametrize(path) then
-    pytest.discover_instances(python, get_script(), path)
+  if runner == "pytest" then
+    pytest.start_test_instance_discovery_if_needed(
+      pytest_discover_instances,
+      python,
+      get_script(),
+      path
+    )
   end
 
   -- Parse the file while pytest is running
@@ -124,7 +129,9 @@ function PythonNeotestAdapter.discover_positions(path)
     require_namespaces = runner == "unittest",
   })
 
-  pytest.add_discovered_positions(root, positions, path)
+  if runner == "pytest" then
+    pytest.add_any_discovered_positions(root, positions, path)
+  end
 
   return positions
 end

--- a/lua/neotest-python/init.lua
+++ b/lua/neotest-python/init.lua
@@ -118,6 +118,7 @@ local function add_test_instances(positions, test_instances)
 
             new_data.id = data.id .. test_instance
             new_data.name = data.name .. test_instance
+            new_data.should_skip = true
 
             local new_pos = value:new(new_data, {}, value._key, {}, {})
             logger.debug("NT", new_pos)

--- a/lua/neotest-python/init.lua
+++ b/lua/neotest-python/init.lua
@@ -81,14 +81,14 @@ function PythonNeotestAdapter.filter_dir(name)
 end
 
 
-local function add_test_instances(positions, test_instances)
+local function add_test_instances(root, positions, test_instances)
     for _, value in positions:iter_nodes() do
         local data = value:data()
         if data.type ~= "test" then
             goto continue
         end
         logger.debug("N", data)
-        local comparable_id = string.match(data.id, ".*/(.*)")
+        local comparable_id = string.match(data.id, root .. "/(.*)")
         if test_instances[comparable_id] == nil then
             goto continue
         end
@@ -174,7 +174,7 @@ function PythonNeotestAdapter.discover_positions(path)
   -- Wait for pytest to complete, and merge its results into the TS tree
   async.fn.jobwait({pytest_job})
 
-  add_test_instances(positions, test_instances)
+  add_test_instances(root, positions, test_instances)
 
   return positions
 end

--- a/lua/neotest-python/init.lua
+++ b/lua/neotest-python/init.lua
@@ -97,14 +97,10 @@ local function add_test_instances(positions, test_instances)
         for _, test_instance in pairs(test_instances[comparable_id]) do
             logger.debug("T", test_instance, data.id .. test_instance)
 
-            local new_data = {}
-            for k,v in pairs(data) do
-                new_data[k] = v
-            end
-
-            new_data.id = data.id .. test_instance
-            new_data.name = data.name .. test_instance
-            new_data.should_skip = true
+            local new_data = vim.tbl_extend("force", data, {
+                id = data.id .. test_instance,
+                name = data.name .. test_instance,
+            })
 
             local new_pos = value:new(new_data, {}, value._key, {}, {})
             logger.debug("NT", new_pos)

--- a/lua/neotest-python/init.lua
+++ b/lua/neotest-python/init.lua
@@ -82,20 +82,11 @@ function PythonNeotestAdapter.filter_dir(name)
 end
 
 ---@async
----@return Tree | nil
+---@return neotest.Tree | nil
 function PythonNeotestAdapter.discover_positions(path)
-  local root = PythonNeotestAdapter.root(path)
+  local root = PythonNeotestAdapter.root(path) or vim.loop.cwd()
   local python = get_python(root)
   local runner = get_runner(python)
-
-  if runner == "pytest" then
-    pytest.start_test_instance_discovery_if_needed(
-      pytest_discover_instances,
-      python,
-      get_script(),
-      path
-    )
-  end
 
   -- Parse the file while pytest is running
   local query = [[
@@ -129,8 +120,8 @@ function PythonNeotestAdapter.discover_positions(path)
     require_namespaces = runner == "unittest",
   })
 
-  if runner == "pytest" then
-    pytest.add_any_discovered_test_instances(root, positions, path)
+  if runner == "pytest" and pytest_discover_instances then
+    pytest.augment_positions(python, get_script(), path, positions, root)
   end
 
   return positions

--- a/lua/neotest-python/init.lua
+++ b/lua/neotest-python/init.lua
@@ -171,7 +171,7 @@ function PythonNeotestAdapter.discover_positions(path)
     require_namespaces = runner == "unittest",
   })
 
-  local cmd = table.concat(vim.tbl_flatten({ get_python(), get_script(), "--collect" , path}), " ")
+  local cmd = table.concat(vim.tbl_flatten({ get_python(), get_script(), "--collect" , path}), " ") .. " 2>&1"
   logger.debug(cmd)
   local handle = io.popen(cmd)
   local result = handle:read("*a")

--- a/lua/neotest-python/init.lua
+++ b/lua/neotest-python/init.lua
@@ -101,6 +101,7 @@ local function add_test_instances(root, positions, test_instances)
             local new_data = vim.tbl_extend("force", data, {
                 id = data.id .. test_instance,
                 name = data.name .. test_instance,
+                range = nil,
             })
 
             local new_pos = value:new(new_data, {}, value._key, {}, {})

--- a/lua/neotest-python/init.lua
+++ b/lua/neotest-python/init.lua
@@ -88,7 +88,8 @@ local function add_test_instances(root, positions, test_instances)
             goto continue
         end
         logger.debug("N", data)
-        local comparable_id = string.match(data.id, root .. "/(.*)")
+        local _, end_idx = string.find(data.id, root .. "/", 1, true)
+        local comparable_id = string.sub(data.id, end_idx + 1)
         if test_instances[comparable_id] == nil then
             goto continue
         end

--- a/lua/neotest-python/init.lua
+++ b/lua/neotest-python/init.lua
@@ -130,7 +130,7 @@ function PythonNeotestAdapter.discover_positions(path)
   })
 
   if runner == "pytest" then
-    pytest.add_any_discovered_positions(root, positions, path)
+    pytest.add_any_discovered_test_instances(root, positions, path)
   end
 
   return positions

--- a/lua/neotest-python/init.lua
+++ b/lua/neotest-python/init.lua
@@ -171,9 +171,13 @@ function PythonNeotestAdapter.discover_positions(path)
     require_namespaces = runner == "unittest",
   })
 
-  local handle = io.popen(table.concat(vim.tbl_flatten({ get_python(), get_script(), "--collect" , path}), " "))
+  local cmd = table.concat(vim.tbl_flatten({ get_python(), get_script(), "--collect" , path}), " ")
+  logger.debug(cmd)
+  local handle = io.popen(cmd)
   local result = handle:read("*a")
   handle:close()
+
+  logger.debug(result)
 
   test_instances_from_pytest(ret, result)
 

--- a/lua/neotest-python/init.lua
+++ b/lua/neotest-python/init.lua
@@ -16,6 +16,7 @@ end
 
 local dap_args
 local is_test_file = base.is_test_file
+local pytest_discover_instances = false
 
 local function get_strategy_config(strategy, python, program, args)
   local config = {
@@ -134,7 +135,7 @@ function PythonNeotestAdapter.discover_positions(path)
 
   local pytest_job
   local test_instances = {}
-  if runner == "pytest" and has_parametrize(path) then
+  if runner == "pytest" and pytest_discover_instances and has_parametrize(path) then
     -- Launch an async job to collect test instances from pytest
     local cmd = table.concat(vim.tbl_flatten({ python, get_script(), "--pytest-collect" , path}), " ")
     logger.debug("Running test instance discovery:", cmd)
@@ -312,6 +313,9 @@ setmetatable(PythonNeotestAdapter, {
     end
     if type(opts.dap) == "table" then
       dap_args = opts.dap
+    end
+    if opts.pytest_discover_instances ~= nil then
+      pytest_discover_instances = opts.pytest_discover_instances
     end
     return PythonNeotestAdapter
   end,

--- a/lua/neotest-python/init.lua
+++ b/lua/neotest-python/init.lua
@@ -142,7 +142,7 @@ function PythonNeotestAdapter.discover_positions(path)
   local test_instances = {}
   if runner == "pytest" and has_parametrize(path) then
     -- Launch an async job to collect test instances from pytest
-    local cmd = table.concat(vim.tbl_flatten({ python, get_script(), "--collect" , path}), " ")
+    local cmd = table.concat(vim.tbl_flatten({ python, get_script(), "--pytest-collect" , path}), " ")
     logger.debug(cmd)
 
     _, pytest_job = pcall(async.fn.jobstart, cmd, {

--- a/lua/neotest-python/init.lua
+++ b/lua/neotest-python/init.lua
@@ -88,7 +88,7 @@ local function add_test_instances(positions, test_instances)
             goto continue
         end
         logger.debug("N", data)
-        local comparable_id = data.id:gmatch(".*/(.*)")()
+        local comparable_id = string.match(data.id, ".*/(.*)")
         if test_instances[comparable_id] == nil then
             goto continue
         end

--- a/lua/neotest-python/init.lua
+++ b/lua/neotest-python/init.lua
@@ -83,47 +83,47 @@ end
 
 
 local function add_test_instances(root, positions, test_instances)
-    for _, value in positions:iter_nodes() do
-        local data = value:data()
-        if data.type ~= "test" then
-            goto continue
-        end
-        local _, end_idx = string.find(data.id, root .. "/", 1, true)
-        local comparable_id = string.sub(data.id, end_idx + 1)
-        if test_instances[comparable_id] == nil then
-            goto continue
-        end
-        for _, test_instance in pairs(test_instances[comparable_id]) do
-            local new_data = vim.tbl_extend("force", data, {
-                id = data.id .. test_instance,
-                name = data.name .. test_instance,
-                range = nil,
-            })
-
-            local new_pos = value:new(new_data, {}, value._key, {}, {})
-            value:add_child(new_data.id, new_pos)
-        end
-        ::continue::
+  for _, value in positions:iter_nodes() do
+    local data = value:data()
+    if data.type ~= "test" then
+      goto continue
     end
+    local _, end_idx = string.find(data.id, root .. "/", 1, true)
+    local comparable_id = string.sub(data.id, end_idx + 1)
+    if test_instances[comparable_id] == nil then
+      goto continue
+    end
+    for _, test_instance in pairs(test_instances[comparable_id]) do
+      local new_data = vim.tbl_extend("force", data, {
+        id = data.id .. test_instance,
+        name = data.name .. test_instance,
+        range = nil,
+      })
+
+      local new_pos = value:new(new_data, {}, value._key, {}, {})
+      value:add_child(new_data.id, new_pos)
+    end
+    ::continue::
+  end
 end
 
 ---@async
 ---@param path string
 ---@return boolean
 local function has_parametrize(path)
-    local query = [[
-      ;; Detect parametrize decorators
-      (decorator
-        (call
-          function:
-            (attribute
-              attribute: (identifier) @parametrize
-              (#eq? @parametrize "parametrize"))))
-    ]]
-    local content = lib.files.read(path)
-    local ts_root, lang = lib.treesitter.get_parse_root(path, content, { fast = true })
-    local built_query = lib.treesitter.normalise_query(lang, query)
-    return built_query:iter_matches(ts_root, content)() ~= nil
+  local query = [[
+    ;; Detect parametrize decorators
+    (decorator
+      (call
+        function:
+          (attribute
+            attribute: (identifier) @parametrize
+            (#eq? @parametrize "parametrize"))))
+  ]]
+  local content = lib.files.read(path)
+  local ts_root, lang = lib.treesitter.get_parse_root(path, content, { fast = true })
+  local built_query = lib.treesitter.normalise_query(lang, query)
+  return built_query:iter_matches(ts_root, content)() ~= nil
 end
 
 ---@async
@@ -147,9 +147,9 @@ function PythonNeotestAdapter.discover_positions(path)
           local test_id, param_id = string.match(line, "(.+::.+)(%[.+%])\r?")
           if test_id and param_id then
             if test_instances[test_id] == nil then
-                test_instances[test_id] = {param_id}
+              test_instances[test_id] = {param_id}
             else
-                table.insert(test_instances[test_id], param_id)
+              table.insert(test_instances[test_id], param_id)
             end
           end
         end

--- a/lua/neotest-python/init.lua
+++ b/lua/neotest-python/init.lua
@@ -88,9 +88,8 @@ function PythonNeotestAdapter.discover_positions(path)
   local python = get_python(root)
   local runner = get_runner(python)
 
-  local pytest_job, test_instances
   if runner == "pytest" and pytest_discover_instances and pytest.has_parametrize(path) then
-    pytest_job, test_instances = pytest.discover_instances(python, get_script(), path)
+    pytest.discover_instances(python, get_script(), path)
   end
 
   -- Parse the file while pytest is running
@@ -125,12 +124,7 @@ function PythonNeotestAdapter.discover_positions(path)
     require_namespaces = runner == "unittest",
   })
 
-  if pytest_job then
-    -- Wait for pytest to complete, and merge its results into the TS tree
-    async.fn.jobwait({pytest_job})
-
-    pytest.add_test_instances(root, positions, test_instances)
-  end
+  pytest.add_discovered_positions(root, positions)
 
   return positions
 end

--- a/lua/neotest-python/pytest.lua
+++ b/lua/neotest-python/pytest.lua
@@ -1,0 +1,49 @@
+local lib = require("neotest.lib")
+
+local M = {}
+
+function M.add_test_instances(root, positions, test_instances)
+  for _, value in positions:iter_nodes() do
+    local data = value:data()
+    if data.type ~= "test" then
+      goto continue
+    end
+    local _, end_idx = string.find(data.id, root .. "/", 1, true)
+    local comparable_id = string.sub(data.id, end_idx + 1)
+    if test_instances[comparable_id] == nil then
+      goto continue
+    end
+    for _, test_instance in pairs(test_instances[comparable_id]) do
+      local new_data = vim.tbl_extend("force", data, {
+        id = data.id .. test_instance,
+        name = data.name .. test_instance,
+        range = nil,
+      })
+
+      local new_pos = value:new(new_data, {}, value._key, {}, {})
+      value:add_child(new_data.id, new_pos)
+    end
+    ::continue::
+  end
+end
+
+---@async
+---@param path string
+---@return boolean
+function M.has_parametrize(path)
+  local query = [[
+    ;; Detect parametrize decorators
+    (decorator
+      (call
+        function:
+          (attribute
+            attribute: (identifier) @parametrize
+            (#eq? @parametrize "parametrize"))))
+  ]]
+  local content = lib.files.read(path)
+  local ts_root, lang = lib.treesitter.get_parse_root(path, content, { fast = true })
+  local built_query = lib.treesitter.normalise_query(lang, query)
+  return built_query:iter_matches(ts_root, content)() ~= nil
+end
+
+return M

--- a/lua/neotest-python/pytest.lua
+++ b/lua/neotest-python/pytest.lua
@@ -8,6 +8,10 @@ local pytest_jobs = {}
 local test_instances = {}
 
 ---@async
+---Add test instances for path in root to positions
+---@param root string
+---@param positions Tree
+---@param path string
 local function add_test_instances(root, positions, path)
   local test_instances_for_path = test_instances[path]
   if not test_instances_for_path then
@@ -57,8 +61,11 @@ local function has_parametrize(path)
 end
 
 ---@async
+---Launch an async job to discover test instances for path (by running script using python)
+---@param python string[]
+---@param script string
+---@param path string
 local function discover_instances(python, script, path)
-  -- Launch an async job to collect test instances from pytest
   local cmd = table.concat(vim.tbl_flatten({ python, script, "--pytest-collect", path }), " ")
   logger.debug("Running test instance discovery:", cmd)
 
@@ -82,7 +89,11 @@ local function discover_instances(python, script, path)
 end
 
 ---@async
-function M.add_any_discovered_positions(root, positions, path)
+---Add any test instances discovered for path in root to positions
+---@param root string
+---@param positions Tree
+---@param path string
+function M.add_any_discovered_test_instances(root, positions, path)
   local pytest_job = pytest_jobs[path]
   if pytest_job then
     -- Wait for pytest to complete, and merge its results into the TS tree
@@ -92,6 +103,12 @@ function M.add_any_discovered_positions(root, positions, path)
   end
 end
 
+---@async
+---Launch pytest to discover test instances for path, if configured
+---@param pytest_discover_instances boolean
+---@param python string[]
+---@param script string
+---@param path string
 function M.start_test_instance_discovery_if_needed(pytest_discover_instances, python, script, path)
   if pytest_discover_instances and has_parametrize(path) then
     discover_instances(python, script, path)

--- a/lua/neotest-python/pytest.lua
+++ b/lua/neotest-python/pytest.lua
@@ -31,8 +31,8 @@ local function add_test_instances(root, positions, path)
       local new_data = vim.tbl_extend("force", data, {
         id = data.id .. test_instance,
         name = data.name .. test_instance,
-        range = nil,
       })
+      new_data.range = nil
 
       local new_pos = value:new(new_data, {}, value._key, {}, {})
       value:add_child(new_data.id, new_pos)

--- a/lua/neotest-python/pytest.lua
+++ b/lua/neotest-python/pytest.lua
@@ -46,7 +46,7 @@ local function has_parametrize(path)
 end
 
 ---@async
----Launch an async job to discover test instances for path (by running script using python)
+---Discover test instances for path (by running script using python)
 ---@param python string[]
 ---@param script string
 ---@param path string

--- a/lua/neotest-python/pytest.lua
+++ b/lua/neotest-python/pytest.lua
@@ -40,7 +40,7 @@ end
 ---@async
 ---@param path string
 ---@return boolean
-function M.has_parametrize(path)
+local function has_parametrize(path)
   local query = [[
     ;; Detect parametrize decorators
     (decorator
@@ -57,7 +57,7 @@ function M.has_parametrize(path)
 end
 
 ---@async
-function M.discover_instances(python, script, path)
+local function discover_instances(python, script, path)
   -- Launch an async job to collect test instances from pytest
   local cmd = table.concat(vim.tbl_flatten({ python, script, "--pytest-collect", path }), " ")
   logger.debug("Running test instance discovery:", cmd)
@@ -82,13 +82,19 @@ function M.discover_instances(python, script, path)
 end
 
 ---@async
-function M.add_discovered_positions(root, positions, path)
+function M.add_any_discovered_positions(root, positions, path)
   local pytest_job = pytest_jobs[path]
   if pytest_job then
     -- Wait for pytest to complete, and merge its results into the TS tree
     async.fn.jobwait({ pytest_job })
 
     add_test_instances(root, positions, path)
+  end
+end
+
+function M.start_test_instance_discovery_if_needed(pytest_discover_instances, python, script, path)
+  if pytest_discover_instances and has_parametrize(path) then
+    discover_instances(python, script, path)
   end
 end
 

--- a/neotest.py
+++ b/neotest.py
@@ -15,10 +15,6 @@ def add_to_path():
 
 with add_to_path():
     from neotest_python import main
-    from neotest_python import pytest
 
 if __name__ == "__main__":
-    if "--collect" in sys.argv:
-        pytest.main(sys.argv[1:])
-    else:
-        main(sys.argv[1:])
+    main(sys.argv[1:])

--- a/neotest.py
+++ b/neotest.py
@@ -15,6 +15,10 @@ def add_to_path():
 
 with add_to_path():
     from neotest_python import main
+    from neotest_python import pytest
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    if "--collect" in sys.argv:
+        pytest.main(sys.argv[1:])
+    else:
+        main(sys.argv[1:])

--- a/neotest_python/__init__.py
+++ b/neotest_python/__init__.py
@@ -41,6 +41,12 @@ parser.add_argument("args", nargs="*")
 
 
 def main(argv: List[str]):
+    if "--pytest-collect" in argv:
+        argv.remove("--pytest-collect")
+        from .pytest import collect
+        collect(argv)
+        return
+
     args = parser.parse_args(argv)
     adapter = get_adapter(TestRunner(args.runner))
 

--- a/neotest_python/pytest.py
+++ b/neotest_python/pytest.py
@@ -180,6 +180,5 @@ class NeotestDebugpyPlugin:
             additional_info.is_tracing -= 1
 
 
-def main(args):
-    args.remove("--collect")
+def collect(args):
     pytest.main(['--collect-only', '-q'] + args)

--- a/neotest_python/pytest.py
+++ b/neotest_python/pytest.py
@@ -1,3 +1,4 @@
+import os.path
 from io import StringIO
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Union
@@ -176,3 +177,8 @@ class NeotestDebugpyPlugin:
             py_db.stop_on_unhandled_exception(py_db, thread, additional_info, excinfo)
         finally:
             additional_info.is_tracing -= 1
+
+
+def main(args):
+    args.remove("--collect")
+    pytest.main(['--collect-only', '-q'] + args)

--- a/neotest_python/pytest.py
+++ b/neotest_python/pytest.py
@@ -107,6 +107,7 @@ class NeotestResultCollector:
         if getattr(item, "callspec", None) is not None:
             # Parametrized test
             msg_prefix = f"[{item.callspec.id}] "
+            pos_id += f"[{item.callspec.id}]"
         if report.outcome == "failed":
             exc_repr = report.longrepr
             # Test fails due to condition outside of test e.g. xfail

--- a/neotest_python/pytest.py
+++ b/neotest_python/pytest.py
@@ -1,4 +1,3 @@
-import os.path
 from io import StringIO
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Union


### PR DESCRIPTION
(This is very rough, so I'm opening it as draft: this is the first Lua I've written that wasn't neovim configuration, so it will need substantial rework before it can land!)

These commits modify `PythonNeotestAdapter.discover_positions(path)` to:
* call `pytest --collect-only <path>` (via `neotest_python.py`)
* parse pytest's output to determine any test instances (`[a-b-c]`)
* iterate over the tests collected by the existing TS query and add child nodes for each discovered test instance

This would fix #35

---

It also includes one modification to get the UX to work correctly: individual test instances aren't tied to locations in `pytest`, as they can be generated by the cross-product of several decorators and/or fixtures. It follows that the cursor position should still select the parent test, and not the test instances. As far as I can tell, this isn't currently achievable in neotest: setting `range = nil` on the position results in all sorts of errors, and leaving it the same as the parent test results in the last test instance being focused.

With this hack to neotest core, and 602a0ac1c9a92c5b498b9af4950272796e38605a, positions can declare that they should be excluded from focus (a better variable name would not go amiss, but it's getting late!):

```diff
--- a/lua/neotest/client/init.lua
+++ b/lua/neotest/client/init.lua
@@ -123,7 +123,9 @@ function NeotestClient:get_nearest(file_path, row, args)
   for _, pos in positions:iter_nodes() do
     local data = pos:data()
     if data.range and data.range[1] <= row then
-      nearest = pos
+      if not data.should_skip then
+          nearest = pos
+      end
     else
       return nearest, adapter_id
     end
```

This results in the parameters being displayed in the summary, while the parent test is selected:
![neotest-param-1](https://user-images.githubusercontent.com/62736/200735120-97e3d3d9-5096-4dab-be75-7a2a94426535.png)

`neotest.run.run` in a test definition will run all test instances:
![neotest-param-2](https://user-images.githubusercontent.com/62736/200735217-60408fc3-9c87-4af2-8ed2-743637951091.png)

And you can selectively run individual test instances from the summary window (the highlighting of the test name is from another plugin, oopsie):
![neotest-param-3](https://user-images.githubusercontent.com/62736/200735301-c9ee2313-299f-4db6-9104-fe3ff2f22b8f.png)