### PR TITLE
Fix for detection of poetry venvs when outside of poetry shell

### DIFF
--- a/lua/neotest-python/base.lua
+++ b/lua/neotest-python/base.lua
@@ -56,7 +56,7 @@ function M.get_python_command(root)
   if lib.files.exists("pyproject.toml") then
     local success, exit_code, data = pcall(
       lib.process.run,
-      { "poetry", "env", "info", "-p" },
+      { "poetry", "run", "poetry", "env", "info", "-p" },
       { stdout = true }
     )
     if success and exit_code == 0 then


### PR DESCRIPTION
If you are not in a `poetry shell`, the venv detection does not work. This patch prepends `poetry run` before `poetry env info -p`, which makes venv detection work both inside and outside the poetry subshell.