### PR TITLE
fix: correctly parse failing subtests

### DIFF
--- a/neotest_python/unittest.py
+++ b/neotest_python/unittest.py
@@ -17,6 +17,8 @@ class UnittestNeotestAdapter(NeotestAdapter):
         return str(Path(inspect.getmodule(case).__file__).absolute())  # type: ignore
 
     def case_id_elems(self, case) -> List[str]:
+        if case.__class__.__name__ == '_SubTest':
+            case = case.test_case
         file = self.case_file(case)
         elems = [file, case.__class__.__name__]
         if isinstance(case, TestCase):


### PR DESCRIPTION
Failing subtests failed to set the testmethod & class to failed. Now if a subtest fails, it indicates that its parent test case failed.