### PR TITLE
fix: unittest error empty module name

### DIFF
--- a/neotest_python/unittest.py
+++ b/neotest_python/unittest.py
@@ -38,6 +38,12 @@ class UnittestNeotestAdapter(NeotestAdapter):
 
         # Otherwise, convert the ID into a dotted path, relative to current dir
         relative_file = os.path.relpath(path, os.getcwd())
+        path_header = os.path.dirname(relative_file)
+        if '.' in os.path.split(path_header)[0]:
+            os.chdir(os.path.dirname(path))
+            sys.path.insert(0, os.getcwd())
+            _argv = ".".join([os.path.splitext(os.path.basename(relative_file))[0] , *child_ids])
+            return [*args,_argv]        
         relative_stem = os.path.splitext(relative_file)[0]
         relative_dotted = relative_stem.replace(os.sep, ".")
         return [*args, ".".join([relative_dotted, *child_ids])]

--- a/neotest_python/unittest.py
+++ b/neotest_python/unittest.py
@@ -29,13 +29,6 @@ class UnittestNeotestAdapter(NeotestAdapter):
     def convert_args(self, case_id: str, args: List[str]) -> List[str]:
         """Converts a neotest ID into test specifier for unittest"""
         path, *child_ids = case_id.split("::")
-        if not child_ids:
-            if os.path.isfile(path):
-                # Test files can be passed directly to unittest
-                return [path]
-            # Directories need to be run via the 'discover' argument
-            return ["discover", "-s", path, *args]
-
         # Otherwise, convert the ID into a dotted path, relative to current dir
         relative_file = os.path.relpath(path, os.getcwd())
         path_header = os.path.dirname(relative_file)


### PR DESCRIPTION
when tests file path start with '.' (such as:'.vscode/tests/test_demo.py'), unittest will load error for the path.  

bad idea:  jump directly to the tests path.

have a better idea?