### PR TITLE
fix - use `--verbosity=0` when collecting pytest parametrized tests

### DIFF
--- a/neotest_python/pytest.py
+++ b/neotest_python/pytest.py
@@ -180,4 +180,4 @@ class NeotestDebugpyPlugin:
 
 
 def collect(args):
-    pytest.main(['--collect-only', '-q'] + args)
+    pytest.main(["--collect-only", "--verbosity=0", "-q"] + args)


### PR DESCRIPTION
Hi,
I noticed that parametrized tests are not correctly collected when you use `-v` option in `tox.ini` or `pytest.ini` because current implementation rely on `-q` option which is negated by `-v` option. This can be fixed by specifying `--verbosity=0` which overrides any number of `-v` options ( note that verbosity parameter need to be before `-q` parameter ).

I tested this with `pytest.ini`:
```
[pytest]
addopts = -vvv
```
and it returns correct output:
```
❯ pytest --collect-only --verbosity=0 -q
tests/test_this.py::test_true[True]
tests/test_this.py::test_true[False]
```