### PR TITLE
Extract python_functions & use it in treesitter query

### DIFF
--- a/get_pytest_options.py
+++ b/get_pytest_options.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+def main():
+    # use a dummy marker to make sure no test is run
+    pytest.main(args=["-k", "neotest_none"], plugins=["neotest_python.pytest"])
+
+
+if __name__ == "__main__":
+    main()

--- a/neotest_python/pytest.py
+++ b/neotest_python/pytest.py
@@ -1,3 +1,4 @@
+import json
 from io import StringIO
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Union
@@ -7,6 +8,11 @@ from _pytest._code.code import ExceptionRepr
 from _pytest.terminal import TerminalReporter
 
 from .base import NeotestAdapter, NeotestError, NeotestResult, NeotestResultStatus
+
+
+def pytest_collection_modifyitems(config):
+    config = {"python_functions": config.getini("python_functions")[0]}
+    print(f"\n{json.dumps(config)}\n")
 
 
 class PytestNeotestAdapter(NeotestAdapter):


### PR DESCRIPTION
This PR aims to resolve #65 : discover pytest test positions when `python_functions` is set to a value different to `test`.

I placed  the `python_functions` value extraction code in the `discover_positions`. This is not ideal because it causes this code to be called once for each test file while calling it only once is enough, but I did not find any satisfying place. Please do not hesitate to suggest improvements on this issue if you see any. 

Also it might not be very idiomatic as this is my first time writing lua code in a non-personal project.