### PR TITLE
feat: luarocks support

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -1,0 +1,32 @@
+---
+name: Push to Luarocks
+
+on:
+  push:
+    tags:
+      - '*'
+  release:
+    types:
+      - created
+    tags:
+      - '*'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Required to count the commits
+      - name: Get Version
+        run: echo "LUAROCKS_VERSION=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v5
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          version: ${{ env.LUAROCKS_VERSION }}
+          dependencies: |
+            neotest

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,23 @@
+---
+permissions:
+  contents: write
+  pull-requests: write
+
+name: Release Please
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        with:
+          release-type: simple
+          package-name: neotest-python
+          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}


### PR DESCRIPTION
Hey :wave: 

### Summary

This PR is part of a push to get neovim plugins on [LuaRocks](https://luarocks.org/labels/neovim).

See also:

- [rocks.nvim](https://github.com/nvim-neorocks/rocks.nvim), a new luarocks-based plugin manager.
- [this blog post](https://mrcjkb.github.io/posts/2023-01-10-luarocks-tag-release.html).

### Things done:

* Add a release-please workflow that creates release PRs with SemVer versioning based on [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* Add a workflow that publishes tags to LuaRocks when a tag or release is pushed.

The workflows are based on [this guide](https://github.com/vhyrro/sample-luarocks-plugin) by @vhyrro.

### Notes:

* On each merge to `master`, the `release-please` workflow creates (or updates an existing) release PR.
* You decide when to merge release PRs.
  Doing so will result in a SemVer tag, and a GitHub release, which will trigger the `luarocks` workflow.
* In the `luarocks` github action, tagged releases are installed locally and then published to luarocks.org.
* For the luarocks workflow to work, someone with a luarocks.org account will have to add their [API key](https://luarocks.org/settings/api-keys) to this repo's [GitHub actions secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
  (@rcarriga has an API key for the [neotest](https://luarocks.org/modules/neotest) account).
* Due to a shortcoming in LuaRocks (https://github.com/luarocks/luarocks-site/issues/188), the `neovim` and/or `vim` labels have to be added  to the LuaRocks package manually (after the first upload), for this plugin to show up in https://luarocks.org/labels/neovim or https://luarocks.org/labels/vim, respectively.