### PR TITLE
fix: remove global print function call

### DIFF
--- a/lua/neotest-python/adapter.lua
+++ b/lua/neotest-python/adapter.lua
@@ -96,8 +96,7 @@ return function(config)
       local strategy_config
       if args.strategy == "dap" then
         strategy_config =
-            base.create_dap_config(python_command, script_path, script_args, config.dap_args)
-        P(config, strategy_config)
+          base.create_dap_config(python_command, script_path, script_args, config.dap_args)
       end
       ---@type neotest.RunSpec
       return {


### PR DESCRIPTION
This commit removes a call to an unknown print global function.

Closes #78 