### PR TITLE
fix(query): explicitly opt-in to legacy behavior

### DIFF
--- a/lua/neotest-python/pytest.lua
+++ b/lua/neotest-python/pytest.lua
@@ -42,7 +42,7 @@ local function has_parametrize(path)
   local content = lib.files.read(path)
   local ts_root, lang = lib.treesitter.get_parse_root(path, content, { fast = true })
   local built_query = lib.treesitter.normalise_query(lang, query)
-  return built_query:iter_matches(ts_root, content)() ~= nil
+  return built_query:iter_matches(ts_root, content, _, _, { all = false })() ~= nil
 end
 
 ---@async


### PR DESCRIPTION
After https://github.com/neovim/neovim/commit/6913c5e1d975a11262d08b3339d50b579e6b6bb8 in Neovim nightly, neotest returns No tests found (tested with neotest-python). Since it's mentioned in the PR that the option all = false will be removed in the future, maybe a more robust approach would be preferable, but I don't have the knowledge to implement it. This is just a hotfix until someone else comes with something better.