### PR TITLE
Added duplicate --failfast check

### DIFF
--- a/neotest_python/django_unittest.py
+++ b/neotest_python/django_unittest.py
@@ -70,10 +70,11 @@ class DjangoNeotestAdapter(CaseUtilsMixin, NeotestAdapter):
             def add_arguments(cls, parser):
                 DiscoverRunner.add_arguments(parser)
                 parser.add_argument("--verbosity", nargs="?", default=2)
-                parser.add_argument(
-                    "--failfast",
-                    action="store_true",
-                )
+                if "failfast" not in parser.parse_args([]):
+                    parser.add_argument(
+                        "--failfast",
+                        action="store_true",
+                    )
 
             # override
             def get_resultclass(self):


### PR DESCRIPTION
`--failfast` was *somewhat* recently added to DiscoverRunner: https://github.com/django/django/commit/0a560eab550696dbc163d57258ef6f3cdb9511a3 

Neotest trying to add it as well raises this error:
```
....
  File "/home/neal/.local/share/nvim/lazy/neotest-python/neotest_python/django_unittest.py", line 125, in run
    DjangoUnittestRunner.add_arguments(parser)
  File "/home/neal/.local/share/nvim/lazy/neotest-python/neotest_python/django_unittest.py", line 73, in add_arguments
    parser.add_argument(
  File "/usr/local/lib/python3.12/argparse.py", line 1490, in add_argument
    return self._add_action(action)
           ^^^^^^^^^^^^^^^^^^^^^^^^
....
argparse.ArgumentError: argument --failfast: conflicting option string: --failfast
```

I've added a simple check to see if the argument is already in the namespace.

Tested with:
* Neovim v0.10.0
* Python v3.10, Django v3.2.4 
* Python v3.12, Django v5.1.1