### PR TITLE
fix(django): make the test runner non-interactive by default

### DIFF
--- a/neotest_python/django_unittest.py
+++ b/neotest_python/django_unittest.py
@@ -64,6 +64,7 @@ class DjangoNeotestAdapter(CaseUtilsMixin, NeotestAdapter):
         class DjangoUnittestRunner(CaseUtilsMixin, DiscoverRunner):
             def __init__(self, **kwargs):
                 django_setup()
+                kwargs["interactive"] = False
                 DiscoverRunner.__init__(self, **kwargs)
 
             @classmethod


### PR DESCRIPTION
Django test workflow includes the setup and teardown of a test database. If the test is stopped via require("neotest").run.stop() during execution, the database is not torn down properly and on the next launch it prompts the user whether it should be deleted, which can be seen in the output panel:
```
Creating test database for alias 'default' ('test_db')...
  Got an error creating the test database: database "test_db" already exists

  Type 'yes' if you would like to try deleting the test database 'test_db', or 'no' to cancel:·
```
From what I understand, there isn't a way to interact with the tests ran via require("neotest").run.run(), so they should probably be non-interactive and destroy the db by default. Usually, this is done by passing a `--noinput` flag when launching tests via manage.py or overriding the default test runner with a custom one in settings.py, but since neotest defines its own runner, this fix does not work. For some reason, the `noinput` arg is not created in`DiscoverRunner.add_arguments`, so it can't be passed via args in the neotest-python config and should instead be passed as a kwarg when initializing the runner. The most basic fix is to just make it non-interactive by default, this could probably be parametrized by adding another argument to the parser, but I don't see a reason to do so.

