### PR TITLE
Adapt test position discovery to pytest’s  option

### DIFF
--- a/lua/neotest-python/adapter.lua
+++ b/lua/neotest-python/adapter.lua
@@ -52,6 +52,7 @@ return function(config)
 
   ---@type neotest.Adapter
   return {
+
     name = "neotest-python",
     root = base.get_root,
     filter_dir = function(name)
@@ -64,7 +65,7 @@ return function(config)
       local python_command = config.get_python_command(root)
       local runner = config.get_runner(python_command)
 
-      local positions = lib.treesitter.parse_positions(path, base.treesitter_queries, {
+      local positions = lib.treesitter.parse_positions(path, base.treesitter_queries(runner, config, python_command), {
         require_namespaces = runner == "unittest",
       })
 

--- a/neotest_python/__init__.py
+++ b/neotest_python/__init__.py
@@ -58,6 +58,13 @@ def main(argv: List[str]):
         collect(argv)
         return
 
+    if "--pytest-extract-test-name-template" in argv:
+        argv.remove("--pytest-extract-test-name-template")
+        from .pytest import extract_test_name_template
+
+        extract_test_name_template(argv)
+        return
+
     args = parser.parse_args(argv)
     adapter = get_adapter(TestRunner(args.runner), args.emit_parameterized_ids)
 

--- a/neotest_python/pytest.py
+++ b/neotest_python/pytest.py
@@ -1,4 +1,5 @@
 from io import StringIO
+import json
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Union
 
@@ -203,6 +204,17 @@ class NeotestDebugpyPlugin:
             py_db.stop_on_unhandled_exception(py_db, thread, additional_info, excinfo)
         finally:
             additional_info.is_tracing -= 1
+
+
+class TestNameTemplateExtractor:
+    @staticmethod
+    def pytest_collection_modifyitems(config):
+        config = {"python_functions": config.getini("python_functions")[0]}
+        print(f"\n{json.dumps(config)}\n")
+
+
+def extract_test_name_template(args):
+    pytest.main(args=["-k", "neotest_none"], plugins=[TestNameTemplateExtractor])
 
 
 def collect(args):


### PR DESCRIPTION
This PR aims to resolve https://github.com/nvim-neotest/neotest-python/issues/65 : discover pytest test positions when python_functions is set to a value different to test.

I placed the python_functions value extraction code in the `discover_positions` function.Please do not hesitate to suggest improvements on this issue if you see any.