### PR TITLE
chore: Replace use of deprecated vim.tbl_flatten

### DIFF
--- a/lua/neotest-python/base.lua
+++ b/lua/neotest-python/base.lua
@@ -111,7 +111,7 @@ end
 local function scan_test_function_pattern(runner, config, python_command)
   local test_function_pattern = "^test"
   if runner == "pytest" and config.pytest_discovery then
-    local cmd = vim.tbl_flatten({ python_command, M.get_script_path(), "--pytest-extract-test-name-template" })
+    local cmd = vim.iter({ python_command, M.get_script_path(), "--pytest-extract-test-name-template" }):flatten():totable()
     local _, data = lib.process.run(cmd, { stdout = true, stderr = true })
 
     for line in vim.gsplit(data.stdout, "\n", true) do


### PR DESCRIPTION
vim.tbl_flatten is deprecated and will be removed in 0.13. Just replaced it with the recommendation in the deprecation notice.

For some reason discovering tests did not work anymore after upgrading from 0.11.x to 0.12.1 even though vim.tbl_flatten still works in this version. Replacing it fixes test discovery for me though and it needs to be done before 0.13 anyway.