### PR TITLE
Fix/pytest config project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 
 Session.vim
 
+tmp/

--- a/lua/neotest-python/adapter.lua
+++ b/lua/neotest-python/adapter.lua
@@ -65,7 +65,7 @@ return function(config)
       local python_command = config.get_python_command(root)
       local runner = config.get_runner(python_command)
 
-      local positions = lib.treesitter.parse_positions(path, base.treesitter_queries(runner, config, python_command), {
+      local positions = lib.treesitter.parse_positions(path, base.treesitter_queries(runner, config, python_command, root), {
         require_namespaces = runner == "unittest",
       })
 

--- a/lua/neotest-python/base.lua
+++ b/lua/neotest-python/base.lua
@@ -107,21 +107,45 @@ end
 ---@param python_command string[]
 ---@param config neotest-python._AdapterConfig
 ---@param runner string
----@return string
-local function scan_test_function_pattern(runner, config, python_command)
+---@return table {test_pattern: string, namespace_pattern: string}
+local function scan_pytest_config(runner, config, python_command)
   local test_function_pattern = "^test"
+  local namespace_pattern = "" -- For describe_prefixes
+  
   if runner == "pytest" and config.pytest_discovery then
     local cmd = vim.tbl_flatten({ python_command, M.get_script_path(), "--pytest-extract-test-name-template" })
     local _, data = lib.process.run(cmd, { stdout = true, stderr = true })
 
     for line in vim.gsplit(data.stdout, "\n", true) do
-      if string.sub(line, 1, 1) == "{" and string.find(line, "python_functions") ~= nil then
+      if string.sub(line, 1, 1) == "{" then
         local pytest_option = vim.json.decode(line)
-        test_function_pattern = pytest_option.python_functions
+        
+        -- Extract python_functions pattern
+        if pytest_option.python_functions then
+          test_function_pattern = pytest_option.python_functions
+        end
+        
+        -- Extract describe_prefixes pattern (from pytest-describe plugin)
+        if pytest_option.describe_prefixes then
+          local prefixes = vim.split(pytest_option.describe_prefixes, " ", { trimempty = true })
+          local prefix_patterns = vim.tbl_map(function(p)
+            return "^" .. p .. "_"
+          end, prefixes)
+          namespace_pattern = table.concat(prefix_patterns, "|")
+        end
       end
     end
   end
-  return test_function_pattern
+  
+  -- Default namespace patterns if none configured
+  if namespace_pattern == "" then
+    namespace_pattern = "^(describe_|context_|when_|given_|scenario_|requirement_)"
+  end
+  
+  return {
+    test_pattern = test_function_pattern,
+    namespace_pattern = namespace_pattern,
+  }
 end
 
 ---@param python_command string[]
@@ -129,9 +153,19 @@ end
 ---@param runner string
 ---@return string
 M.treesitter_queries = function(runner, config, python_command)
-  local test_function_pattern = scan_test_function_pattern(runner, config, python_command)
+  local patterns = scan_pytest_config(runner, config, python_command)
+  local test_function_pattern = patterns.test_pattern
+  local namespace_pattern = patterns.namespace_pattern
+  
   return string.format([[
-    ;; Match undecorated functions
+    ;; Match container functions (describe_*, context_*, when_*, given_*, scenario_*, requirement_*)
+    ;; These create namespaces for organizing tests
+    ((function_definition
+      name: (identifier) @namespace.name)
+      (#match? @namespace.name "%s"))
+      @namespace.definition
+
+    ;; Match undecorated test functions
     ((function_definition
       name: (identifier) @test.name)
       (#match? @test.name "%s"))
@@ -148,7 +182,7 @@ M.treesitter_queries = function(runner, config, python_command)
     (decorated_definition
       (class_definition
        name: (identifier) @namespace.name))
-      @namespace.definition
+       @namespace.definition
 
     ;; Match undecorated classes: namespaces nest so #not-has-parent is used
     ;; to ensure each namespace is annotated only once
@@ -158,7 +192,7 @@ M.treesitter_queries = function(runner, config, python_command)
       @namespace.definition
      (#not-has-parent? @namespace.definition decorated_definition)
     )
-  ]], test_function_pattern, test_function_pattern)
+  ]], namespace_pattern, test_function_pattern, test_function_pattern)
 end
 
 M.get_root =

--- a/lua/neotest-python/base.lua
+++ b/lua/neotest-python/base.lua
@@ -113,7 +113,9 @@ local function scan_pytest_config(runner, config, python_command)
   local namespace_pattern = "" -- For describe_prefixes
   local class_pattern = "" -- For python_classes
 
-  if runner == "pytest" and config.pytest_discovery then
+  -- Extract pytest config patterns regardless of pytest_discovery setting
+  -- pytest_discovery controls parameterized test discovery, not pattern extraction
+  if runner == "pytest" then
     local cmd = vim.tbl_flatten({
       python_command,
       M.get_script_path(),

--- a/lua/neotest-python/base.lua
+++ b/lua/neotest-python/base.lua
@@ -107,10 +107,11 @@ end
 ---@param python_command string[]
 ---@param config neotest-python._AdapterConfig
 ---@param runner string
----@return table {test_pattern: string, namespace_pattern: string}
+---@return table {test_pattern: string, namespace_pattern: string, class_pattern: string}
 local function scan_pytest_config(runner, config, python_command)
   local test_function_pattern = "^test"
   local namespace_pattern = "" -- For describe_prefixes
+  local class_pattern = "" -- For python_classes
 
   if runner == "pytest" and config.pytest_discovery then
     local cmd = vim.tbl_flatten({
@@ -157,6 +158,23 @@ local function scan_pytest_config(runner, config, python_command)
           end, prefixes)
           namespace_pattern = table.concat(prefix_patterns, "|")
         end
+
+        -- Extract python_classes pattern (for class-based tests like BDD)
+        if pytest_option.python_classes then
+          local classes = pytest_option.python_classes
+          -- Handle both string and table types for robustness
+          if type(classes) == "table" then
+            -- Already a table (from legacy JSON array format), use directly
+            classes = classes
+          else
+            -- String format, split by spaces
+            classes = vim.split(classes, " ", { trimempty = true })
+          end
+          local class_patterns = vim.tbl_map(function(p)
+            return "^" .. p:gsub("%*", "")
+          end, classes)
+          class_pattern = table.concat(class_patterns, "|")
+        end
       end
     end
   end
@@ -166,9 +184,15 @@ local function scan_pytest_config(runner, config, python_command)
     namespace_pattern = "^describe_|^context_|^when_|^given_|^scenario_|^requirement_"
   end
 
+  -- Default class patterns if none configured
+  if class_pattern == "" then
+    class_pattern = "^Test"
+  end
+
   return {
     test_pattern = test_function_pattern,
     namespace_pattern = namespace_pattern,
+    class_pattern = class_pattern,
   }
 end
 
@@ -180,6 +204,7 @@ M.treesitter_queries = function(runner, config, python_command)
   local patterns = scan_pytest_config(runner, config, python_command)
   local test_function_pattern = patterns.test_pattern
   local namespace_pattern = patterns.namespace_pattern
+  local class_pattern = patterns.class_pattern
 
   return string.format(
     [[
@@ -203,22 +228,45 @@ M.treesitter_queries = function(runner, config, python_command)
         (#match? @test.name "%s")))
         @test.definition
 
-    ;; Match decorated classes, including decorators in definition
+    ;; Match decorated classes matching python_classes pattern
     (decorated_definition
       (class_definition
-       name: (identifier) @namespace.name))
+       name: (identifier) @namespace.name)
+       (#match? @namespace.name "%s"))
        @namespace.definition
 
-    ;; Match undecorated classes: namespaces nest so #not-has-parent is used
-    ;; to ensure each namespace is annotated only once
+    ;; Match undecorated classes matching python_classes pattern
+    ;; namespaces nest so #not-has-parent is used to ensure each namespace is annotated only once
     (
      (class_definition
       name: (identifier) @namespace.name)
       @namespace.definition
-     (#not-has-parent? @namespace.definition decorated_definition)
+      (#match? @namespace.name "%s")
+      (#not-has-parent? @namespace.definition decorated_definition)
     )
+
+    ;; Match test methods inside classes
+    ((class_definition
+      body: (block
+        (function_definition
+          name: (identifier) @test.name)
+          (#match? @test.name "%s"))))
+      @test.definition
+
+    ;; Match decorated test methods inside classes
+    ((class_definition
+      body: (block
+        (decorated_definition
+          (function_definition
+            name: (identifier) @test.name)
+            (#match? @test.name "%s")))))
+      @test.definition
   ]],
     namespace_pattern,
+    test_function_pattern,
+    test_function_pattern,
+    class_pattern,
+    class_pattern,
     test_function_pattern,
     test_function_pattern
   )

--- a/lua/neotest-python/base.lua
+++ b/lua/neotest-python/base.lua
@@ -215,7 +215,13 @@ M.treesitter_queries = function(runner, config, python_command)
       (#match? @namespace.name "%s"))
       @namespace.definition
 
-    ;; Match undecorated test functions
+    ;; Match classes matching python_classes pattern - these are also namespaces
+    ((class_definition
+      name: (identifier) @namespace.name)
+      (#match? @namespace.name "%s"))
+      @namespace.definition
+
+    ;; Match undecorated test functions (top-level and inside classes)
     ((function_definition
       name: (identifier) @test.name)
       (#match? @test.name "%s"))
@@ -227,45 +233,8 @@ M.treesitter_queries = function(runner, config, python_command)
         name: (identifier) @test.name)
         (#match? @test.name "%s")))
         @test.definition
-
-    ;; Match decorated classes matching python_classes pattern
-    (decorated_definition
-      (class_definition
-       name: (identifier) @namespace.name)
-       (#match? @namespace.name "%s"))
-       @namespace.definition
-
-    ;; Match undecorated classes matching python_classes pattern
-    ;; namespaces nest so #not-has-parent is used to ensure each namespace is annotated only once
-    (
-     (class_definition
-      name: (identifier) @namespace.name)
-      @namespace.definition
-      (#match? @namespace.name "%s")
-      (#not-has-parent? @namespace.definition decorated_definition)
-    )
-
-    ;; Match test methods inside classes
-    ((class_definition
-      body: (block
-        (function_definition
-          name: (identifier) @test.name)
-          (#match? @test.name "%s")))
-      @test.definition)
-
-    ;; Match decorated test methods inside classes
-    ((class_definition
-      body: (block
-        (decorated_definition
-          (function_definition
-            name: (identifier) @test.name)
-            (#match? @test.name "%s"))))
-      @test.definition)
   ]],
     namespace_pattern,
-    test_function_pattern,
-    test_function_pattern,
-    class_pattern,
     class_pattern,
     test_function_pattern,
     test_function_pattern

--- a/lua/neotest-python/base.lua
+++ b/lua/neotest-python/base.lua
@@ -111,7 +111,7 @@ end
 local function scan_pytest_config(runner, config, python_command)
   local test_function_pattern = "^test"
   local namespace_pattern = "" -- For describe_prefixes
-  
+
   if runner == "pytest" and config.pytest_discovery then
     local cmd = vim.tbl_flatten({
       python_command,
@@ -123,19 +123,35 @@ local function scan_pytest_config(runner, config, python_command)
     for line in vim.gsplit(data.stdout, "\n", true) do
       if string.sub(line, 1, 1) == "{" then
         local pytest_option = vim.json.decode(line)
-        
-         -- Extract python_functions pattern
-         if pytest_option.python_functions then
-           local patterns = vim.split(pytest_option.python_functions, " ", { trimempty = true })
-           local regex_parts = vim.tbl_map(function(p)
-             return "^" .. p:gsub("%*", "")
-           end, patterns)
-           test_function_pattern = table.concat(regex_parts, "|")
-         end
-        
+
+        -- Extract python_functions pattern
+        if pytest_option.python_functions then
+          local patterns = pytest_option.python_functions
+          -- Handle both string and table types for robustness
+          if type(patterns) == "table" then
+            -- Already a table (from legacy JSON array format), use directly
+            patterns = patterns
+          else
+            -- String format, split by spaces
+            patterns = vim.split(patterns, " ", { trimempty = true })
+          end
+          local regex_parts = vim.tbl_map(function(p)
+            return "^" .. p:gsub("%*", "")
+          end, patterns)
+          test_function_pattern = table.concat(regex_parts, "|")
+        end
+
         -- Extract describe_prefixes pattern (from pytest-describe plugin)
         if pytest_option.describe_prefixes then
-          local prefixes = vim.split(pytest_option.describe_prefixes, " ", { trimempty = true })
+          local prefixes = pytest_option.describe_prefixes
+          -- Handle both string and table types for robustness
+          if type(prefixes) == "table" then
+            -- Already a table (from legacy JSON array format), use directly
+            prefixes = prefixes
+          else
+            -- String format, split by spaces
+            prefixes = vim.split(prefixes, " ", { trimempty = true })
+          end
           local prefix_patterns = vim.tbl_map(function(p)
             return "^" .. p .. "_"
           end, prefixes)
@@ -144,12 +160,12 @@ local function scan_pytest_config(runner, config, python_command)
       end
     end
   end
-  
+
   -- Default namespace patterns if none configured
   if namespace_pattern == "" then
-    namespace_pattern = "^(describe_|context_|when_|given_|scenario_|requirement_)"
+    namespace_pattern = "^describe_|^context_|^when_|^given_|^scenario_|^requirement_"
   end
-  
+
   return {
     test_pattern = test_function_pattern,
     namespace_pattern = namespace_pattern,
@@ -164,7 +180,7 @@ M.treesitter_queries = function(runner, config, python_command)
   local patterns = scan_pytest_config(runner, config, python_command)
   local test_function_pattern = patterns.test_pattern
   local namespace_pattern = patterns.namespace_pattern
-  
+
   return string.format(
     [[
     ;; Match container functions (describe_*, context_*, when_*, given_*, scenario_*, requirement_*)

--- a/lua/neotest-python/base.lua
+++ b/lua/neotest-python/base.lua
@@ -215,13 +215,7 @@ M.treesitter_queries = function(runner, config, python_command)
       (#match? @namespace.name "%s"))
       @namespace.definition
 
-    ;; Match classes matching python_classes pattern - these are also namespaces
-    ((class_definition
-      name: (identifier) @namespace.name)
-      (#match? @namespace.name "%s"))
-      @namespace.definition
-
-    ;; Match undecorated test functions (top-level and inside classes)
+    ;; Match test functions (both top-level and inside classes)
     ((function_definition
       name: (identifier) @test.name)
       (#match? @test.name "%s"))
@@ -233,11 +227,25 @@ M.treesitter_queries = function(runner, config, python_command)
         name: (identifier) @test.name)
         (#match? @test.name "%s")))
         @test.definition
+
+    ;; Match classes as namespaces (with pytest python_classes filter)
+    ((class_definition
+      name: (identifier) @namespace.name)
+      (#match? @namespace.name "%s"))
+      @namespace.definition
+
+    ;; Match decorated classes
+    (decorated_definition
+      ((class_definition
+        name: (identifier) @namespace.name)
+        (#match? @namespace.name "%s")))
+        @namespace.definition
   ]],
     namespace_pattern,
-    class_pattern,
     test_function_pattern,
-    test_function_pattern
+    test_function_pattern,
+    class_pattern,
+    class_pattern
   )
 end
 

--- a/lua/neotest-python/base.lua
+++ b/lua/neotest-python/base.lua
@@ -107,9 +107,11 @@ end
 ---@param python_command string[]
 ---@param config neotest-python._AdapterConfig
 ---@param runner string
----@return string
-local function scan_test_function_pattern(runner, config, python_command)
+---@return table {test_pattern: string, namespace_pattern: string}
+local function scan_pytest_config(runner, config, python_command)
   local test_function_pattern = "^test"
+  local namespace_pattern = "" -- For describe_prefixes
+  
   if runner == "pytest" and config.pytest_discovery then
     local cmd = vim.tbl_flatten({
       python_command,
@@ -119,17 +121,39 @@ local function scan_test_function_pattern(runner, config, python_command)
     local _, data = lib.process.run(cmd, { stdout = true, stderr = true })
 
     for line in vim.gsplit(data.stdout, "\n", true) do
-      if string.sub(line, 1, 1) == "{" and string.find(line, "python_functions") ~= nil then
+      if string.sub(line, 1, 1) == "{" then
         local pytest_option = vim.json.decode(line)
-        local patterns = vim.split(pytest_option.python_functions, " ", { trimempty = true })
-        local regex_parts = vim.tbl_map(function(p)
-          return "^" .. p:gsub("%*", "")
-        end, patterns)
-        test_function_pattern = table.concat(regex_parts, "|")
+        
+        -- Extract python_functions pattern
+        if pytest_option.python_functions then
+          local patterns = vim.split(pytest_option.python_functions, " ", { trimempty = true })
+          local regex_parts = vim.tbl_map(function(p)
+            return "^" .. p:gsub("%*", "")
+          end, patterns)
+          test_function_pattern = table.concat(regex_parts, "|")
+        end
+        
+        -- Extract describe_prefixes pattern (from pytest-describe plugin)
+        if pytest_option.describe_prefixes then
+          local prefixes = vim.split(pytest_option.describe_prefixes, " ", { trimempty = true })
+          local prefix_patterns = vim.tbl_map(function(p)
+            return "^" .. p .. "_"
+          end, prefixes)
+          namespace_pattern = table.concat(prefix_patterns, "|")
+        end
       end
     end
   end
-  return test_function_pattern
+  
+  -- Default namespace patterns if none configured
+  if namespace_pattern == "" then
+    namespace_pattern = "^(describe_|context_|when_|given_|scenario_|requirement_)"
+  end
+  
+  return {
+    test_pattern = test_function_pattern,
+    namespace_pattern = namespace_pattern,
+  }
 end
 
 ---@param python_command string[]
@@ -137,10 +161,20 @@ end
 ---@param runner string
 ---@return string
 M.treesitter_queries = function(runner, config, python_command)
-  local test_function_pattern = scan_test_function_pattern(runner, config, python_command)
+  local patterns = scan_pytest_config(runner, config, python_command)
+  local test_function_pattern = patterns.test_pattern
+  local namespace_pattern = patterns.namespace_pattern
+  
   return string.format(
     [[
-    ;; Match undecorated functions
+    ;; Match container functions (describe_*, context_*, when_*, given_*, scenario_*, requirement_*)
+    ;; These create namespaces for organizing tests
+    ((function_definition
+      name: (identifier) @namespace.name)
+      (#match? @namespace.name "%s"))
+      @namespace.definition
+
+    ;; Match undecorated test functions
     ((function_definition
       name: (identifier) @test.name)
       (#match? @test.name "%s"))
@@ -157,7 +191,7 @@ M.treesitter_queries = function(runner, config, python_command)
     (decorated_definition
       (class_definition
        name: (identifier) @namespace.name))
-      @namespace.definition
+       @namespace.definition
 
     ;; Match undecorated classes: namespaces nest so #not-has-parent is used
     ;; to ensure each namespace is annotated only once
@@ -168,6 +202,7 @@ M.treesitter_queries = function(runner, config, python_command)
      (#not-has-parent? @namespace.definition decorated_definition)
     )
   ]],
+    namespace_pattern,
     test_function_pattern,
     test_function_pattern
   )

--- a/lua/neotest-python/base.lua
+++ b/lua/neotest-python/base.lua
@@ -107,9 +107,10 @@ end
 ---@param python_command string[]
 ---@param config neotest-python._AdapterConfig
 ---@param runner string
+---@param root string Project root directory (used as cwd for pytest config extraction)
 ---@return table {test_pattern: string, namespace_pattern: string, class_pattern: string}
-local function scan_pytest_config(runner, config, python_command)
-  local test_function_pattern = "^test"
+local function scan_pytest_config(runner, config, python_command, root)
+  local test_function_pattern = "^test_|^it_"
   local namespace_pattern = "" -- For describe_prefixes
   local class_pattern = "" -- For python_classes
 
@@ -120,6 +121,7 @@ local function scan_pytest_config(runner, config, python_command)
       python_command,
       M.get_script_path(),
       "--pytest-extract-test-name-template",
+      root or "",
     })
     local _, data = lib.process.run(cmd, { stdout = true, stderr = true })
 
@@ -201,9 +203,10 @@ end
 ---@param python_command string[]
 ---@param config neotest-python._AdapterConfig
 ---@param runner string
+---@param root? string Project root directory for reading pytest config
 ---@return string
-M.treesitter_queries = function(runner, config, python_command)
-  local patterns = scan_pytest_config(runner, config, python_command)
+M.treesitter_queries = function(runner, config, python_command, root)
+  local patterns = scan_pytest_config(runner, config, python_command, root)
   local test_function_pattern = patterns.test_pattern
   local namespace_pattern = patterns.namespace_pattern
   local class_pattern = patterns.class_pattern
@@ -216,6 +219,13 @@ M.treesitter_queries = function(runner, config, python_command)
       name: (identifier) @namespace.name)
       (#match? @namespace.name "%s"))
       @namespace.definition
+
+    ;; Match decorated container functions
+    (decorated_definition
+      ((function_definition
+        name: (identifier) @namespace.name)
+        (#match? @namespace.name "%s")))
+        @namespace.definition
 
     ;; Match test functions (both top-level and inside classes)
     ((function_definition
@@ -243,6 +253,7 @@ M.treesitter_queries = function(runner, config, python_command)
         (#match? @namespace.name "%s")))
         @namespace.definition
   ]],
+    namespace_pattern,
     namespace_pattern,
     test_function_pattern,
     test_function_pattern,

--- a/lua/neotest-python/base.lua
+++ b/lua/neotest-python/base.lua
@@ -250,8 +250,8 @@ M.treesitter_queries = function(runner, config, python_command)
       body: (block
         (function_definition
           name: (identifier) @test.name)
-          (#match? @test.name "%s"))))
-      @test.definition
+          (#match? @test.name "%s")))
+      @test.definition)
 
     ;; Match decorated test methods inside classes
     ((class_definition
@@ -259,8 +259,8 @@ M.treesitter_queries = function(runner, config, python_command)
         (decorated_definition
           (function_definition
             name: (identifier) @test.name)
-            (#match? @test.name "%s")))))
-      @test.definition
+            (#match? @test.name "%s"))))
+      @test.definition)
   ]],
     namespace_pattern,
     test_function_pattern,

--- a/lua/neotest-python/base.lua.bak
+++ b/lua/neotest-python/base.lua.bak
@@ -111,21 +111,13 @@ end
 local function scan_test_function_pattern(runner, config, python_command)
   local test_function_pattern = "^test"
   if runner == "pytest" and config.pytest_discovery then
-    local cmd = vim.tbl_flatten({
-      python_command,
-      M.get_script_path(),
-      "--pytest-extract-test-name-template",
-    })
+    local cmd = vim.tbl_flatten({ python_command, M.get_script_path(), "--pytest-extract-test-name-template" })
     local _, data = lib.process.run(cmd, { stdout = true, stderr = true })
 
     for line in vim.gsplit(data.stdout, "\n", true) do
       if string.sub(line, 1, 1) == "{" and string.find(line, "python_functions") ~= nil then
         local pytest_option = vim.json.decode(line)
-        local patterns = vim.split(pytest_option.python_functions, " ", { trimempty = true })
-        local regex_parts = vim.tbl_map(function(p)
-          return "^" .. p:gsub("%*", "")
-        end, patterns)
-        test_function_pattern = table.concat(regex_parts, "|")
+        test_function_pattern = pytest_option.python_functions
       end
     end
   end
@@ -138,8 +130,7 @@ end
 ---@return string
 M.treesitter_queries = function(runner, config, python_command)
   local test_function_pattern = scan_test_function_pattern(runner, config, python_command)
-  return string.format(
-    [[
+  return string.format([[
     ;; Match undecorated functions
     ((function_definition
       name: (identifier) @test.name)
@@ -167,10 +158,7 @@ M.treesitter_queries = function(runner, config, python_command)
       @namespace.definition
      (#not-has-parent? @namespace.definition decorated_definition)
     )
-  ]],
-    test_function_pattern,
-    test_function_pattern
-  )
+  ]], test_function_pattern, test_function_pattern)
 end
 
 M.get_root =

--- a/neotest_python/pytest.py
+++ b/neotest_python/pytest.py
@@ -249,6 +249,11 @@ class TestNameTemplateExtractor:
         if describe_prefixes:
             extracted_config["describe_prefixes"] = " ".join(describe_prefixes)
 
+        # Extract python_classes if configured
+        python_classes = config.getini("python_classes")
+        if python_classes:
+            extracted_config["python_classes"] = " ".join(python_classes)
+
         print(f"\n{json.dumps(extracted_config)}\n")
 
 

--- a/neotest_python/pytest.py
+++ b/neotest_python/pytest.py
@@ -240,7 +240,7 @@ class NeotestDebugpyPlugin:
 class TestNameTemplateExtractor:
     @staticmethod
     def pytest_collection_modifyitems(config):
-        config = {"python_functions": config.getini("python_functions")[0]}
+        config = {"python_functions": " ".join(config.getini("python_functions"))}
         print(f"\n{json.dumps(config)}\n")
 
 

--- a/neotest_python/pytest.py
+++ b/neotest_python/pytest.py
@@ -245,9 +245,12 @@ class TestNameTemplateExtractor:
         }
 
         # Extract describe_prefixes if pytest-describe is configured
-        describe_prefixes = config.getini("describe_prefixes")
-        if describe_prefixes:
-            extracted_config["describe_prefixes"] = " ".join(describe_prefixes)
+        try:
+            describe_prefixes = config.getini("describe_prefixes")
+            if describe_prefixes:
+                extracted_config["describe_prefixes"] = " ".join(describe_prefixes)
+        except ValueError:
+            pass  # pytest-describe not installed; use Lua defaults
 
         # Extract python_classes if configured
         python_classes = config.getini("python_classes")
@@ -257,10 +260,90 @@ class TestNameTemplateExtractor:
         print(f"\n{json.dumps(extracted_config)}\n")
 
 
+def _read_pytest_config_from_files(root: str) -> dict:
+    """Read pytest ini options directly from config files without running pytest.
+
+    Supports pyproject.toml, pytest.ini, setup.cfg, and tox.ini.
+    This avoids triggering pytest collection on large projects.
+    """
+    from pathlib import Path
+    import sys
+    import configparser
+
+    root_path = Path(root)
+    result = {}
+
+    # --- pyproject.toml ---
+    pyproject = root_path / "pyproject.toml"
+    if pyproject.exists():
+        try:
+            if sys.version_info >= (3, 11):
+                import tomllib
+
+                with open(pyproject, "rb") as f:
+                    data = tomllib.load(f)
+            else:
+                import tomli  # type: ignore[import]
+
+                with open(pyproject, "rb") as f:
+                    data = tomli.load(f)
+            opts = data.get("tool", {}).get("pytest", {}).get("ini_options", {})
+            for key in ("python_functions", "python_classes", "describe_prefixes"):
+                if key in opts:
+                    val = opts[key]
+                    result[key] = " ".join(val) if isinstance(val, list) else str(val)
+        except Exception:
+            pass
+
+    if result:
+        return result
+
+    # --- pytest.ini ---
+    pytest_ini = root_path / "pytest.ini"
+    if pytest_ini.exists():
+        cfg = configparser.ConfigParser()
+        cfg.read(pytest_ini)
+        if cfg.has_section("pytest"):
+            for key in ("python_functions", "python_classes", "describe_prefixes"):
+                if cfg.has_option("pytest", key):
+                    result[key] = cfg.get("pytest", key).strip()
+
+    if result:
+        return result
+
+    # --- setup.cfg ---
+    setup_cfg = root_path / "setup.cfg"
+    if setup_cfg.exists():
+        cfg = configparser.ConfigParser()
+        cfg.read(setup_cfg)
+        if cfg.has_section("tool:pytest"):
+            for key in ("python_functions", "python_classes", "describe_prefixes"):
+                if cfg.has_option("tool:pytest", key):
+                    result[key] = cfg.get("tool:pytest", key).strip()
+
+    if result:
+        return result
+
+    # --- tox.ini ---
+    tox_ini = root_path / "tox.ini"
+    if tox_ini.exists():
+        cfg = configparser.ConfigParser()
+        cfg.read(tox_ini)
+        if cfg.has_section("pytest"):
+            for key in ("python_functions", "python_classes", "describe_prefixes"):
+                if cfg.has_option("pytest", key):
+                    result[key] = cfg.get("pytest", key).strip()
+
+    return result
+
+
 def extract_test_name_template(args) -> int:
-    return int(
-        pytest.main(args=["-k", "neotest_none"], plugins=[TestNameTemplateExtractor])
-    )
+    # args[0] is the project root directory passed from Lua.
+    # Parse config files directly to avoid triggering pytest collection on large projects.
+    root = args[0] if args else "."
+    config = _read_pytest_config_from_files(root)
+    print(f"\n{json.dumps(config)}\n")
+    return 0
 
 
 def collect(args) -> int:

--- a/neotest_python/pytest.py
+++ b/neotest_python/pytest.py
@@ -240,8 +240,14 @@ class NeotestDebugpyPlugin:
 class TestNameTemplateExtractor:
     @staticmethod
     def pytest_collection_modifyitems(config):
-        config = {"python_functions": config.getini("python_functions")[0]}
-        print(f"\n{json.dumps(config)}\n")
+        extracted_config = {"python_functions": config.getini("python_functions")[0]}
+
+        # Extract describe_prefixes if pytest-describe is configured
+        describe_prefixes = config.getini("describe_prefixes")
+        if describe_prefixes:
+            extracted_config["describe_prefixes"] = " ".join(describe_prefixes)
+
+        print(f"\n{json.dumps(extracted_config)}\n")
 
 
 def extract_test_name_template(args) -> int:

--- a/neotest_python/pytest.py
+++ b/neotest_python/pytest.py
@@ -240,8 +240,16 @@ class NeotestDebugpyPlugin:
 class TestNameTemplateExtractor:
     @staticmethod
     def pytest_collection_modifyitems(config):
-        config = {"python_functions": " ".join(config.getini("python_functions"))}
-        print(f"\n{json.dumps(config)}\n")
+        extracted_config = {
+            "python_functions": " ".join(config.getini("python_functions"))
+        }
+
+        # Extract describe_prefixes if pytest-describe is configured
+        describe_prefixes = config.getini("describe_prefixes")
+        if describe_prefixes:
+            extracted_config["describe_prefixes"] = " ".join(describe_prefixes)
+
+        print(f"\n{json.dumps(extracted_config)}\n")
 
 
 def extract_test_name_template(args) -> int:


### PR DESCRIPTION

### Problem

When using custom pytest naming conventions (e.g. `should_*`, `it_*` for functions or `A_*`, `Describe*` for classes), neotest-python silently ignores the project configuration and falls back to defaults. Tests with non-default prefixes are never discovered.

A secondary symptom is that on large projects the plugin **hangs Neovim** during test discovery.

### Environment

- neotest-python (latest)
- pytest with custom `[tool.pytest.ini_options]` in `pyproject.toml`
- optionally: `pytest-describe` plugin

### Reproduction

`pyproject.toml`:
```toml
[tool.pytest.ini_options]
python_functions = "should_*" it_* test_*"
python_classes   = "Describe* A_* Test*"
describe_prefixes = ["describe", "context"]
```

```python
def describe_math():
    def it_adds():
        assert 1 + 1 == 2          # not discovered

class DescribeMath:
    def should_multiply(self):
        assert 2 * 3 == 6          # not discovered

def test_fallback():
    assert True                    # discovered (default prefix)
```

Only `test_fallback` is discovered. Functions with `it_`, `should_` prefixes and
classes with `Describe*` prefix are invisible to the plugin.

### Root causes

**1. Subprocess runs without `cwd` — reads the wrong `pyproject.toml`**

`scan_pytest_config` in `base.lua` launches the config-extraction subprocess via
`lib.process.run` with no working directory. The process inherits Neovim's `cwd`
(which may differ from the project root), so pytest finds the wrong — or no —
`pyproject.toml` and returns defaults.

**2. Hang on large projects**

The fix attempted by passing the project root as a pytest collection path
(`pytest.main(["-k", "neotest_none", root])`) causes pytest to walk the entire
`testpaths` tree before printing the config JSON, blocking Neovim indefinitely on
large projects.

**3. `config.getini("describe_prefixes")` crashes silently**

In `pytest.py`, `TestNameTemplateExtractor.pytest_collection_modifyitems` calls
`config.getini("describe_prefixes")` without a `try/except`. When `pytest-describe`
is not installed this raises `ValueError`, crashing the subprocess before any JSON
is printed. Lua receives no output and uses hardcoded defaults.

**4. Wrong fallback default for `test_function_pattern`**

The hardcoded Lua fallback is `"^test"`, which matches unintended names like
`testing_helper` or `testutils` and misses the `it_*` prefix entirely. It should
be `"^test_|^it_"`.

**5. Missing treesitter query for decorated namespace functions**

Decorated test functions (`@decorator\ndef test_foo()`) and decorated classes are
handled, but decorated *namespace/container* functions are not:

```python
@some_decorator
def describe_math():       # ← not captured as a namespace
    def it_adds(): ...
```

### Proposed fix

**`neotest_python/pytest.py`** — replace the `pytest.main()` call in
`extract_test_name_template` with direct parsing of the config files
(`pyproject.toml` via `tomllib`/`tomli`, `pytest.ini` / `setup.cfg` / `tox.ini`
via `configparser`). This is instantaneous, requires no pytest collection, and
correctly reads the project config regardless of the process working directory.
Also wrap `getini("describe_prefixes")` in `try/except ValueError`.

**`lua/neotest-python/base.lua`** — pass `root` (already computed in
`discover_positions`) through `treesitter_queries` → `scan_pytest_config` → the
subprocess argument list, so the Python script receives the project root explicitly.
Fix the fallback default from `"^test"` to `"^test_|^it_"`. Add a sixth treesitter
query to capture decorated namespace/container functions.

**`lua/neotest-python/adapter.lua`** — pass `root` to `base.treesitter_queries`.
